### PR TITLE
fix: close mobile nav on user action

### DIFF
--- a/common/components/nav/MobileNav.tsx
+++ b/common/components/nav/MobileNav.tsx
@@ -42,7 +42,7 @@ export default function MobileNav({ links, onClose }: MobileNavProps) {
           ))}
         </ul>
         <div className="flex gap-2 flex-col">
-          <NavActions />
+          <NavActions onClose={onClose} />
         </div>
       </div>
     </div>

--- a/common/components/nav/NavActions.tsx
+++ b/common/components/nav/NavActions.tsx
@@ -7,8 +7,8 @@ import { useUser, useClerk } from "@clerk/nextjs";
 function UserActions({ onClose }: NavActionsProps) {
   const { signOut } = useClerk();
 
-  const handleSignOut = () => {
-    signOut();
+  const handleSignOut = async () => {
+    await signOut();
     onClose?.();
   };
 

--- a/common/components/nav/NavActions.tsx
+++ b/common/components/nav/NavActions.tsx
@@ -4,36 +4,61 @@ import Link from "next/link";
 import Button from "@/common/components/ui/Button";
 import { useUser, useClerk } from "@clerk/nextjs";
 
-function UserActions() {
+function UserActions({ onClose }: NavActionsProps) {
   const { signOut } = useClerk();
+
+  const handleSignOut = () => {
+    signOut();
+    onClose?.();
+  };
+
+  const handleDashboard = () => {
+    onClose?.();
+  };
 
   return (
     <>
-      <Button variant="inverted-tealwave" onClick={() => signOut()}>
+      <Button variant="inverted-tealwave" onClick={handleSignOut}>
         Sign Out
       </Button>
-      <Button variant="tealwave" asChild>
+      <Button variant="tealwave" onClick={handleDashboard} asChild>
         <Link href="/dashboard">Dashboard</Link>
       </Button>
     </>
   );
 }
 
-function GuestActions() {
+function GuestActions({ onClose }: NavActionsProps) {
+  const handleSignIn = () => {
+    onClose?.();
+  };
+
+  const handleSignUp = () => {
+    onClose?.();
+  };
+
   return (
     <>
-      <Button variant="inverted-tealwave" asChild>
+      <Button variant="inverted-tealwave" onClick={handleSignIn} asChild>
         <Link href="/sign-in">Sign In</Link>
       </Button>
-      <Button variant="tealwave" asChild>
+      <Button variant="tealwave" onClick={handleSignUp} asChild>
         <Link href="/sign-up">Get Started</Link>
       </Button>
     </>
   );
 }
 
-export default function NavActions() {
+type NavActionsProps = {
+  onClose?: () => void;
+};
+
+export default function NavActions({ onClose }: NavActionsProps) {
   const { user } = useUser();
 
-  return user ? <UserActions /> : <GuestActions />;
+  return user ? (
+    <UserActions onClose={onClose} />
+  ) : (
+    <GuestActions onClose={onClose} />
+  );
 }


### PR DESCRIPTION
This pull request involves modifications to the `MobileNav` and `NavActions` components to handle the `onClose` callback. The changes are aimed at ensuring that the `onClose` function is called appropriately when certain actions are performed.

Key changes include:

* [`common/components/nav/MobileNav.tsx`](diffhunk://#diff-2dc3bcba4e3a752ca60ac123fc94570ab8cf033511a042a7dcdc8a696cd83647L45-R45): Passed the `onClose` callback to the `NavActions` component to ensure it is called when navigation actions are performed.

* [`common/components/nav/NavActions.tsx`](diffhunk://#diff-63f1d322ed02ae921c07835fe0f527c5dce6c6ae9c460eac9d088b6c86f892eeL7-R63): Updated the `UserActions` and `GuestActions` components to accept the `onClose` prop and call it when the sign-out, sign-in, sign-up, or dashboard buttons are clicked.

Fixes #26