### PR TITLE
feat: implement tab component for home page

### DIFF
--- a/common/components/home/index.tsx
+++ b/common/components/home/index.tsx
@@ -15,7 +15,6 @@ import { useState } from "react";
 export default function HomeView() {
   const { loadRecommendations, recommendations, isLoading } =
     useRecommendations();
-  const [activeTab, setActiveTab] = useState("destinations");
 
   const hasRentals =
     recommendations?.rentals && Object.keys(recommendations.rentals).length > 0;
@@ -23,6 +22,10 @@ export default function HomeView() {
     recommendations?.vacation_destinations &&
     Object.keys(recommendations.vacation_destinations).length > 0;
   const hasData = hasRentals || hasDestinations;
+
+  const [activeTab, setActiveTab] = useState(
+    hasDestinations ? "destinations" : "rentals",
+  );
 
   return (
     <>
@@ -44,9 +47,8 @@ export default function HomeView() {
 
         {hasData && (
           <Tabs
-            defaultValue={hasDestinations ? "destinations" : "rentals"}
             value={activeTab}
-            onValueChange={setActiveTab}
+            onValueChange={(value) => setActiveTab(value)}
             className="w-full"
           >
             <div className="flex justify-center mb-8">

--- a/common/components/home/index.tsx
+++ b/common/components/home/index.tsx
@@ -4,46 +4,89 @@ import Container from "@/common/components/atoms/layouts/Container";
 import Hero from "@/common/components/home/hero";
 import useRecommendations from "@/common/providers/recommendations";
 import GridSection from "./grid-section";
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+} from "@/common/components/ui/Tabs";
+import { useState } from "react";
 
 export default function HomeView() {
   const { loadRecommendations, recommendations, isLoading } =
     useRecommendations();
+  const [activeTab, setActiveTab] = useState("destinations");
+
+  const hasRentals =
+    recommendations?.rentals && Object.keys(recommendations.rentals).length > 0;
+  const hasDestinations =
+    recommendations?.vacation_destinations &&
+    Object.keys(recommendations.vacation_destinations).length > 0;
+  const hasData = hasRentals || hasDestinations;
 
   return (
     <>
       <Hero
         onSearch={(answers) => !isLoading && loadRecommendations?.(answers)}
       />
-      <Container as="section" className="py-20 flex flex-col gap-10">
-        {recommendations &&
-          Object.entries(recommendations.rentals).map(([key, value]) => (
-            <div key={key}>
-              {/* Render the section title */}
+      <Container as="section" className="py-20">
+        {!hasData && (
+          <div className="text-center py-10">
+            <h2 className="text-2xl font-semibold text-nightocean mb-4">
+              Discover Your Perfect Getaway
+            </h2>
+            <p className="text-gray-600 max-w-2xl mx-auto">
+              Use the search above to find personalized vacation recommendations
+              tailored just for you.
+            </p>
+          </div>
+        )}
 
-              {/* Render the grid section */}
-              <GridSection
-                title={key.replace(/_/g, " ")}
-                recommendations={value}
-              />
+        {hasData && (
+          <Tabs
+            defaultValue={hasDestinations ? "destinations" : "rentals"}
+            value={activeTab}
+            onValueChange={setActiveTab}
+            className="w-full"
+          >
+            <div className="flex justify-center mb-8">
+              <TabsList>
+                <TabsTrigger value="destinations" disabled={!hasDestinations}>
+                  Destinations
+                </TabsTrigger>
+                <TabsTrigger value="rentals" disabled={!hasRentals}>
+                  Rentals
+                </TabsTrigger>
+              </TabsList>
             </div>
-          ))}
-      </Container>
-      {/*TODO NEED TAB SECTIONS*/}
-      <Container as="section" className="py-20 flex flex-col gap-10">
-        {recommendations &&
-          Object.entries(recommendations.vacation_destinations || []).map(
-            ([key, value]) => (
-              <div key={key}>
-                {/* Render the section title */}
 
-                {/* Render the grid section */}
-                <GridSection
-                  title={key.replace(/_/g, " ")}
-                  recommendations={value}
-                />
-              </div>
-            ),
-          )}
+            <TabsContent value="destinations" className="flex flex-col gap-10">
+              {hasDestinations &&
+                Object.entries(
+                  recommendations!.vacation_destinations || {},
+                ).map(([key, value]) => (
+                  <div key={key}>
+                    <GridSection
+                      title={key.replace(/_/g, " ")}
+                      recommendations={value}
+                    />
+                  </div>
+                ))}
+            </TabsContent>
+
+            <TabsContent value="rentals" className="flex flex-col gap-10">
+              {hasRentals &&
+                Object.entries(recommendations!.rentals).map(([key, value]) => (
+                  <div key={key}>
+                    <GridSection
+                      title={key.replace(/_/g, " ")}
+                      recommendations={value}
+                    />
+                  </div>
+                ))}
+            </TabsContent>
+          </Tabs>
+        )}
       </Container>
     </>
   );

--- a/common/components/ui/Tabs/index.tsx
+++ b/common/components/ui/Tabs/index.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+
+import { cn } from "@/lib/cn";
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-full bg-gray-100 p-1 text-gray-600",
+      className,
+    )}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-full px-4 py-1.5 text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 data-[state=inactive]:hover:bg-gray-200 data-[state=active]:bg-tealwave data-[state=active]:text-white",
+      className,
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn("mt-3 focus-visible:outline-none", className)}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@hookform/resolvers": "^5.0.1",
         "@radix-ui/react-dialog": "^1.1.7",
         "@radix-ui/react-slot": "^1.1.2",
+        "@radix-ui/react-tabs": "^1.1.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "input-otp": "^1.4.2",
@@ -2954,6 +2955,32 @@
       "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.3.tgz",
+      "integrity": "sha512-mM2pxoQw5HJ49rkzwOs7Y6J4oYH22wS8BfK2/bBxROlI4xuR0c4jEenQP63LlTlDkO6Buj2Vt+QYAYcOgqtrXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.3",
+        "@radix-ui/react-slot": "1.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -3016,6 +3043,21 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -3176,6 +3218,37 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.3.tgz",
+      "integrity": "sha512-ufbpLUjZiOg4iYgb2hQrWXEPYX6jOLBbR27bDyAff5GYMRrCzcze8lukjuXVUQvJ6HZe8+oL+hhswDcjmcgVyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collection": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.0.tgz",
@@ -3190,6 +3263,36 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.4.tgz",
+      "integrity": "sha512-fuHMHWSf5SRhXke+DbHXj2wVMo+ghVH30vhX3XVacdXqDl+J4XWafMIGOOER861QpBx1jxgwKXL2dQnfrsd8MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.3",
+        "@radix-ui/react-primitive": "2.0.3",
+        "@radix-ui/react-roving-focus": "1.1.3",
+        "@radix-ui/react-use-controllable-state": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@hookform/resolvers": "^5.0.1",
     "@radix-ui/react-dialog": "^1.1.7",
     "@radix-ui/react-slot": "^1.1.2",
+    "@radix-ui/react-tabs": "^1.1.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "input-otp": "^1.4.2",


### PR DESCRIPTION
This pull request introduces a new tab component for displaying recommendations on the home page.

### Enhancements to Home Page:

* [`common/components/home/index.tsx`](diffhunk://#diff-baa4a32f25f78dad98f569739c8ca75d86c84ebbc22dad228ffb73f4f6ca0ea9R7-R88): Added a tabbed interface to switch between "Destinations" and "Rentals" based on the availability of recommendations. Introduced state management to handle active tabs and conditional rendering to display a message when no data is available.

### New Tabs Component:

* [`common/components/ui/Tabs/index.tsx`](diffhunk://#diff-8d0aa67bf95697cb2fd6c899882b8034f23b52180c76e8c083494cd2e76a3012R1-R52): Implemented a new `Tabs` component using `@radix-ui/react-tabs`. This includes `Tabs`, `TabsList`, `TabsTrigger`, and `TabsContent` components with custom styling and forward refs.

### Dependency Addition:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R26): Added `@radix-ui/react-tabs` as a new dependency to support the tabbed interface.